### PR TITLE
separate `with` statement line

### DIFF
--- a/dbt_coding_conventions.md
+++ b/dbt_coding_conventions.md
@@ -49,7 +49,9 @@
 - CTEs should be formatted like this:
 
 ``` sql
-with events as (
+with
+
+events as (
 
     ...
 
@@ -83,7 +85,9 @@ select * from filtered_events
 
 ### Example SQL
 ```sql
-with my_data as (
+with
+
+my_data as (
 
     select * from {{ ref('my_data') }}
 


### PR DESCRIPTION
**Logic for isolating the `with` statement:**

- Cleanly lines up all the CTE titles to make it easy to quickly browse up and down which CTE might be referenced - improving readability.
- Makes it easy to reorder CTEs after you've typed them all up (i.e. being able to block highlight the CTE without worrying about the with that's attached in the beginning).