### PR TITLE
add explanation for final CTE

### DIFF
--- a/dbt_coding_conventions.md
+++ b/dbt_coding_conventions.md
@@ -76,6 +76,7 @@ Our models (typically) fit into three main categories: staging, marts, base/inte
 - CTE names should be as verbose as needed to convey what they do
 - CTEs with confusing or noteable logic should be commented
 - CTEs that are duplicated across models should be pulled out into their own models
+- create a `final` or similar CTE that you select from as your last line of code. This makes it easier to debug code within a model (without having to comment out code!)
 - CTEs should be formatted like this:
 
 ``` sql


### PR DESCRIPTION
### Summary

During a new hire onboarding, there was a question around why we have a final `select * from final` in our code conventions. While many elements are explained in our style guide, this is only explained [here](https://discourse.getdbt.com/t/why-the-fishtown-sql-style-guide-uses-so-many-ctes/1091) in a discourse post.

I think adding it under the CTE section makes the most sense but let me know if you prefer elsewhere or to simply link to the discourse post